### PR TITLE
Set curl timeout to 30s and add curl_error output to error log

### DIFF
--- a/SDK/RootsratedSDK.php
+++ b/SDK/RootsratedSDK.php
@@ -191,6 +191,7 @@ class RootsRatedSDK {
         $url = $this->getApiURL() . $this->getToken() . '/' . $command;
         $auth = $this->getBasicAuth();
         $options = array(
+            CURLOPT_CONNECTTIMEOUT => 30,
             CURLOPT_URL => $url,
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_HTTPHEADER => array(
@@ -207,11 +208,12 @@ class RootsRatedSDK {
         curl_setopt_array($http, $options);
         $response = curl_exec($http);
         $status_code = curl_getinfo($http, CURLINFO_HTTP_CODE);
+        $error_detail = curl_error($http);
         curl_close($http);
 
         $data = json_decode($response, true);
         if (!$this->isValidArray($data)) {
-            error_log("RootsRated Compass: getData failed for URL " . $url . "; response=\"" . $response . "\"; response code=" . $status_code . "\n");
+            error_log("RootsRated Compass: getData failed for URL " . $url . "; response=\"" . $response . "\"; response code=" . $status_code . "; curl_error=" . $error_detail . "\n");
             return false;
         }
         return $data;


### PR DESCRIPTION
Per the [latest comments](https://app.zenhub.com/workspace/o/rootsrated/issues/issues/471#issuecomment-367196872) on the issue with Montana, they're now seeing a response code of 0 in the logs. My understanding is that this means that the request is not happening, and that calling curl_error after this should yield more information, so I'm adding that output to the error log.

I'm also setting the timeout setting to 30 seconds here, after discovering this week that the endpoint that pulls all channel content in can be quite slow for channels with a lot of distributions (RootsRated/compass_tidal_wp_plugin#32). I don't think this is Montana's problem, but is a good change to make knowing we have that performance problem.