### PR TITLE
Matcha rebrand

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 RootsRated Media
+Copyright (c) 2018 Matcha
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Compass Tidal PHP SDK
+# Matcha PHP SDK
 
 [![Code Climate](https://codeclimate.com/repos/58d2d7a042f14a02710000c0/badges/3f57be90855275bfa1a4/gpa.svg)](https://codeclimate.com/repos/58d2d7a042f14a02710000c0/feed)
 [![Test Coverage](https://codeclimate.com/repos/58d2d7a042f14a02710000c0/badges/3f57be90855275bfa1a4/coverage.svg)](https://codeclimate.com/repos/58d2d7a042f14a02710000c0/coverage)
 [![CircleCI](https://circleci.com/gh/RootsRated/compass_tidal_php_sdk/tree/master.svg?style=svg&circle-token=9ca7bfabe320d6b4a14e8cecc24457f35eb099b0)](https://circleci.com/gh/RootsRated/compass_tidal_php_sdk/tree/master)
 
 A full-featured SDK, written in PHP, to allow simplified access to
-RootsRated Media's Compass platform.
+the Matcha content distribution platform.
 
 ## Requirements
 

--- a/SDK/RootsratedSDK.php
+++ b/SDK/RootsratedSDK.php
@@ -4,7 +4,7 @@ class RootsRatedSDK {
 
     // protected fields
     protected $token;
-    protected $apiURL = 'https://compass.rootsrated.com/tidal/v1_0/';
+    protected $apiURL = 'https://app.getmatcha.com/tidal/v1_0/';
     protected $imageUploadPath;
     protected $key;
     protected $secret;
@@ -207,7 +207,7 @@ class RootsRatedSDK {
 
         $http = curl_init();
         if (!$http) {
-            error_log("RootsRated Compass: curl_init failed\n");
+            error_log("Matcha: curl_init failed\n");
             return false;
         }
         curl_setopt_array($http, $options);
@@ -218,7 +218,7 @@ class RootsRatedSDK {
 
         $data = json_decode($response, true);
         if (!$this->isValidArray($data)) {
-            error_log("RootsRated Compass: getData failed for URL " . $url . "; response=\"" . $response . "\"; response code=" . $status_code . "; curl_error=" . $error_detail . "\n");
+            error_log("Matcha: getData failed for URL " . $url . "; response=\"" . $response . "\"; response code=" . $status_code . "; curl_error=" . $error_detail . "\n");
             return false;
         }
         return $data;
@@ -241,7 +241,7 @@ class RootsRatedSDK {
             (function(r,oo,t,s,ra,te,d){if(!r[ra]){(r.GlobalRootsRatedNamespace=r.GlobalRootsRatedNamespace||[]).push(ra);
             r[ra]=function(){(r[ra].q=r[ra].q||[]).push(arguments)};r[ra].q=r[ra].q||[];te=oo.createElement(t);
             d=oo.getElementsByTagName(t)[0];te.async=1;te.src=s;d.parentNode.insertBefore(te,d)
-            }}(window,document,"script","https://static.rootsrated.com/rootsrated.min.js","rr"));
+            }}(window,document,"script","https://static.getmatcha.com/rootsrated.min.js","rr"));
             rr('config', 'channelToken', '$this->token');
          </script>
 HOOKFUNCTION;

--- a/SDK/RootsratedWebhook.php
+++ b/SDK/RootsratedWebhook.php
@@ -10,34 +10,34 @@ class RootsRatedWebhook
             'CONTENT_LENGTH' => 'Content-Length',
             'CONTENT_MD5'    => 'Content-Md5',
         );
-        foreach ($_SERVER as $key => $value) 
+        foreach ($_SERVER as $key => $value)
         {
-            if (substr($key, 0, 5) === 'HTTP_') 
+            if (substr($key, 0, 5) === 'HTTP_')
             {
                 $key = substr($key, 5);
-                if (!isset($copy_server[$key]) || !isset($_SERVER[$key])) 
+                if (!isset($copy_server[$key]) || !isset($_SERVER[$key]))
                 {
                     $key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', $key))));
                     $headers[$key] = $value;
                 }
-            } 
-            elseif (isset($copy_server[$key])) 
+            }
+            elseif (isset($copy_server[$key]))
             {
                 $headers[$copy_server[$key]] = $value;
             }
         }
-        if (!isset($headers['Authorization'])) 
+        if (!isset($headers['Authorization']))
         {
-            if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) 
+            if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION']))
             {
                 $headers['Authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
-            } 
-            elseif (isset($_SERVER['PHP_AUTH_USER'])) 
+            }
+            elseif (isset($_SERVER['PHP_AUTH_USER']))
             {
                 $basic_pass = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : '';
                 $headers['Authorization'] = 'Basic ' . base64_encode($_SERVER['PHP_AUTH_USER'] . ':' . $basic_pass);
-            } 
-            elseif (isset($_SERVER['PHP_AUTH_DIGEST'])) 
+            }
+            elseif (isset($_SERVER['PHP_AUTH_DIGEST']))
             {
                 $headers['Authorization'] = $_SERVER['PHP_AUTH_DIGEST'];
             }
@@ -48,7 +48,7 @@ class RootsRatedWebhook
     function executeHook($headers, $reqBody, $posts, $sdk) {
         if (!$sdk->checkConfig()) {
             echo '{"message": "Missing credentials", "installed": true}';
-            error_log('RootsRated Compass: unable to execute hook due to missing credentials');
+            error_log('Matcha: unable to execute hook due to missing credentials');
             $this->HTTPStatus(401, '401 Missing credentials');
             return false;
         }
@@ -58,45 +58,45 @@ class RootsRatedWebhook
 
         if ($sdk->validateHookSignature($reqBody, $hookSignature) && strlen($hookName) > 0) {
           $jsonHook = $reqBody ? json_decode($reqBody, true) : '';
-            if (is_array($jsonHook)) 
+            if (is_array($jsonHook))
             {
-                if ($sdk->isAuthenticated() ) 
+                if ($sdk->isAuthenticated() )
                 {
                     $hookName = $jsonHook['hook'];
                     $result = $this->parseHook($jsonHook, $hookName, $posts, $sdk);
-                    if($result === true) 
+                    if($result === true)
                     {
                         $this->HTTPStatus(200, ' 200 OK');
                         echo('{"message":"ok"}');
-                        error_log('RootsRated Compass: successfully executed hook ' . $hookName);
+                        error_log('Matcha: successfully executed hook ' . $hookName);
                         flush();
                         return true;
                     } else {
                         if(gettype($result) === 'string') {
                             echo($result);
                             $this->HTTPStatus(200, '200 OK');
-                            error_log('RootsRated Compass: successfully executed hook ' . $hookName);
+                            error_log('Matcha: successfully executed hook ' . $hookName);
                             return $result;
                         }
-                        error_log('RootsRated Compass: unable to execute hook due to invalid hook name ' . $hookName);
+                        error_log('Matcha: unable to execute hook due to invalid hook name ' . $hookName);
                         $this->HTTPStatus(401, '401 Invalid Hook Name');
                         return false;
                     }
                 } else {
                     echo '{"message": "No Key and/or Secret", "installed": true}';
-                    error_log('RootsRated Compass: unable to execute hook due to missing key and/or secret');
+                    error_log('Matcha: unable to execute hook due to missing key and/or secret');
                     $this->HTTPStatus(401, '401 No Key and/or Secret');
                     return false;
                 }
             } else {
                 echo '{"message": "Server error", "installed": true}';
-                error_log('RootsRated Compass: unable to execute hook due to server error');
+                error_log('Matcha: unable to execute hook due to server error');
                 $this->HTTPStatus(500, '500 Failed');
                 return false;
             }
         } else {
             echo '{"message": "Invalid signature", "installed": true}';
-            error_log('RootsRated Compass: unable to execute hook due to invalid signature');
+            error_log('Matcha: unable to execute hook due to invalid signature');
             $this->HTTPStatus(401, '401 Invalid Hook Signature');
             return false;
         }
@@ -106,8 +106,8 @@ class RootsRatedWebhook
         switch ($hookName) {
             case "distribution_schedule" : $this->postScheduling($jsonHook, $posts,$sdk); break;
             case "distribution_go_live" : $this->postGoLive($jsonHook, $posts, $sdk); break;
-            case "content_update" :  $this->postRevision($jsonHook, $posts, $sdk); break;                   
-            case "distribution_update" :  $this->postUpdate($jsonHook, $posts, $sdk); break; 
+            case "content_update" :  $this->postRevision($jsonHook, $posts, $sdk); break;
+            case "distribution_update" :  $this->postUpdate($jsonHook, $posts, $sdk); break;
             case "distribution_revoke" : $this->postRevoke($jsonHook, $posts, $sdk);break;
             case "service_cancel" : $posts->deactivationPlugin(); break;
             case "service_phone_home" : $result = $this->servicePhoneHome($posts, $sdk); return $result; break;
@@ -119,14 +119,14 @@ class RootsRatedWebhook
 
     private function postScheduling($jsonHook, $posts, $sdk)
     {
-        if(!array_key_exists('distribution', $jsonHook)) 
+        if(!array_key_exists('distribution', $jsonHook))
         {
             return false;
         }
         $rrId = trim($jsonHook['distribution']['id']);
 
         $data = $sdk->getData('content/' . $rrId);
-        if (!$data) 
+        if (!$data)
         {
             return false;
         }
@@ -140,18 +140,18 @@ class RootsRatedWebhook
 
     private function postGoLive($jsonHook, $posts, $sdk)
     {
-        if(!array_key_exists('distribution', $jsonHook)) 
+        if(!array_key_exists('distribution', $jsonHook))
         {
             return false;
         }
 
         $rrId = trim($jsonHook['distribution']['id']);
 
-        if (empty($postId)) 
+        if (empty($postId))
         {
-    
+
             $data = $sdk->getData('content/' . $rrId);
-            if (!$data) 
+            if (!$data)
             {
                 return false;
             }
@@ -170,7 +170,7 @@ class RootsRatedWebhook
         $data = $sdk;
         $rrId = trim($jsonHook['distribution']['id']);
         $tempPost = $data->getData('content/' . $rrId);
-        if (!$tempPost) 
+        if (!$tempPost)
         {
             return false;
         }
@@ -188,7 +188,7 @@ class RootsRatedWebhook
         $rrId = trim($jsonHook['distribution']['id']);
 
         $tempPost = $data->getData('content/' . $rrId);
-        if (!$tempPost) 
+        if (!$tempPost)
         {
             return false;
         }
@@ -204,7 +204,7 @@ class RootsRatedWebhook
     {
         $rrId = trim($jsonHook['distribution']['id']);
         $postType = $sdk->getPostType();
-        
+
         return $posts->postRevoke($rrId, $postType);
     }
 
@@ -212,7 +212,7 @@ class RootsRatedWebhook
     {
 
         if(!$sdk->isAuthenticated())
-        { 
+        {
             return false;
         }
 
@@ -236,7 +236,7 @@ class RootsRatedWebhook
         $results = json_decode($results, true);
         $success = $results["success"];
         curl_close($ch);
-        
+
         if ($success){
             return $request;
         }
@@ -272,7 +272,7 @@ class RootsRatedWebhook
     public function phoneHome($posts, $sdk) {
         $options = $posts->getInfo();
 
-        $plugins = $options['plugins']; 
+        $plugins = $options['plugins'];
         $pluginsJSON = array();
         foreach ($plugins as $plugin) {
             $item = array();
@@ -310,11 +310,11 @@ class RootsRatedWebhook
 
     public function HTTPStatus($code, $message)
     {
-        if (version_compare(phpversion(), '5.4.0', '>=')) 
+        if (version_compare(phpversion(), '5.4.0', '>='))
         {
             http_response_code($code);
-        } 
-        else 
+        }
+        else
         {
             $protocol = (isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0');
             header($protocol . ' ' . $message);

--- a/SDK/config.json
+++ b/SDK/config.json
@@ -4,6 +4,6 @@
     "posttype": "Post",
     "category": "RootsRated",
     "application_path": "",
-    "phone_home_url" : "https://compass.rootsrated.com/tidal/v1_0/" 
+    "phone_home_url" : "https://app.getmatcha.com/tidal/v1_0/"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "rootsrated_media/compass_tidal_sdk",
   "type": "library",
-  "description": "RootsRated Media's PHP SDK for accessing Compass' distribution system",
+  "description": "PHP SDK for accessing the Matcha content distribution system",
   "homepage": "https://github.com/RootsRated/compass_tidal_php_sdk",
   "license": "MIT",
   "require": {

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -5,6 +5,6 @@
     "rootsrated_secret": "FIQkYJul0Pp4UbylwxT9Dw",
     "rootsrated_auth_key": "5bd618debbbe43d5d4c52e17dc120e17f464ac98e9efc3e574907b7310400b2f",
     "rootsrated_token": "oqjfDhS5FB6jdSCVueXKCWJ2",
-    "phone_home_url" : "https://compass.rootsrated.com/tidal/v1_0/"
+    "phone_home_url" : "https://app.getmatcha.com/tidal/v1_0/"
   }
 }

--- a/tests/config/config_testExecuteHook.json
+++ b/tests/config/config_testExecuteHook.json
@@ -5,6 +5,6 @@
     "rootsrated_secret": "FIQkYJul0Pp4UbylwxT9Dw",
     "rootsrated_auth_key": "5bd618debbbe43d5d4c52e17dc120e17f464ac98e9efc3e574907b7310400b2f",
     "rootsrated_token": "oqjfDhS5FB6jdSCVueXKCWJ2",
-    "phone_home_url" : "https://compass.rootsrated.com/tidal/v1_0/"
+    "phone_home_url" : "https://app.getmatcha.com/tidal/v1_0/"
   }
 }

--- a/tests/mocks/hook_body.json
+++ b/tests/mocks/hook_body.json
@@ -7,7 +7,7 @@
     "published_at" : "2016-01-11T13:33:52Z",
     "updated_at" : "2016-01-11T13:33:52Z",
     "meta" : {
-      "api_url" :"https://compass.rootsrated.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
+      "api_url" :"https://app.getmatcha.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
       "template" : {
         "name" : "Experience"
       }

--- a/tests/mocks/hook_cancel.json
+++ b/tests/mocks/hook_cancel.json
@@ -7,7 +7,7 @@
     "published_at" : "2016-01-11T13:33:52Z",
     "updated_at" : "2016-01-11T13:33:52Z",
     "meta" : {
-      "api_url" :"https://compass.rootsrated.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
+      "api_url" :"https://app.getmatcha.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
       "template" : {
         "name" : "Experience"
       }

--- a/tests/mocks/hook_content_update.json
+++ b/tests/mocks/hook_content_update.json
@@ -7,7 +7,7 @@
     "published_at" : "2016-01-11T13:33:52Z",
     "updated_at" : "2016-01-11T13:33:52Z",
     "meta" : {
-      "api_url" :"https://compass.rootsrated.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
+      "api_url" :"https://app.getmatcha.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
       "template" : {
         "name" : "Experience"
       }

--- a/tests/mocks/hook_distribution_update.json
+++ b/tests/mocks/hook_distribution_update.json
@@ -7,7 +7,7 @@
     "published_at" : "2016-01-11T13:33:52Z",
     "updated_at" : "2016-01-11T13:33:52Z",
     "meta" : {
-      "api_url" :"https://compass.rootsrated.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
+      "api_url" :"https://app.getmatcha.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
       "template" : {
         "name" : "Experience"
       }

--- a/tests/mocks/hook_phone_home.json
+++ b/tests/mocks/hook_phone_home.json
@@ -1,20 +1,20 @@
 {
-  "hook":"service_phone_home", 
+  "hook":"service_phone_home",
   "article": {
-    "id":22502, 
-    "title":"Traveling 7,000 Miles Across South America By Bus", 
-    "rootsrated_url": "https://rootsrated.com/stories/traveling-7-000-miles-across-south-america-by-bus", "published_at":"2017-07-13T17:56:58Z", 
-    "updated_at":"2017-07-13T17:56:58Z", 
+    "id":22502,
+    "title":"Traveling 7,000 Miles Across South America By Bus",
+    "rootsrated_url": "https://rootsrated.com/stories/traveling-7-000-miles-across-south-america-by-bus", "published_at":"2017-07-13T17:56:58Z",
+    "updated_at":"2017-07-13T17:56:58Z",
     "meta": {
-      "api_url": "https://compass.rootsrated.com/tidal/LyjvKQC2P1Bo6YHx2VUvF9Et/content/6m6E2bBtDbdBcUVZQ8hXgJHx", 
+      "api_url": "https://app.getmatcha.com/tidal/LyjvKQC2P1Bo6YHx2VUvF9Et/content/6m6E2bBtDbdBcUVZQ8hXgJHx",
       "template":{
         "name":"Story"
         }
       }
-    }, 
+    },
     "distribution": {
-      "id":"6m6E2bBtDbdBcUVZQ8hXgJHx", 
-      "launch_at":"2017-07-14T15:19:51Z", 
+      "id":"6m6E2bBtDbdBcUVZQ8hXgJHx",
+      "launch_at":"2017-07-14T15:19:51Z",
       "channel":{
         "id":"LyjvKQC2P1Bo6YHx2VUvF9Et"
       }

--- a/tests/mocks/hook_revoke.json
+++ b/tests/mocks/hook_revoke.json
@@ -7,7 +7,7 @@
     "published_at" : "2016-01-11T13:33:52Z",
     "updated_at" : "2016-01-11T13:33:52Z",
     "meta" : {
-      "api_url" :"https://compass.rootsrated.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
+      "api_url" :"https://app.getmatcha.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
       "template" : {
         "name" : "Experience"
       }

--- a/tests/mocks/hook_scheduling.json
+++ b/tests/mocks/hook_scheduling.json
@@ -7,7 +7,7 @@
     "published_at" : "2016-01-11T13:33:52Z",
     "updated_at" : "2016-01-11T13:33:52Z",
     "meta" : {
-      "api_url" :"https://compass.rootsrated.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
+      "api_url" :"https://app.getmatcha.com/tidal/UWFSs4z9WrhBmLcTBtFGgH2D/content/KQMkxhHmzxQJ6n3Sdf88zVXC",
       "template" : {
         "name" : "Experience"
       }


### PR DESCRIPTION
These changes are mainly cosmetic, log copy, and in tests, but the one major change is the change of the API URL to https://app.getmatcha.com/tidal/v1_0/.

I've tested on our [staging wordpress site](http://staging-wordpress.rootsrated.media/) with a version of the WordPress plugin that uses this, and distribution works.
