### PR TITLE
Remove use of RootsRated category

### DIFF
--- a/SDK/RootsratedPosts.php
+++ b/SDK/RootsratedPosts.php
@@ -1,9 +1,9 @@
 <?php
 interface RootsRatedPosts {
 
-  public function postScheduling($distribution, $rrId, $catName, $postType);
+  public function postScheduling($distribution, $rrId, $postType);
 
-  public function postGoLive($distribution, $launchAt, $rrId, $catName, $postType);
+  public function postGoLive($distribution, $launchAt, $rrId, $postType);
 
   public function postRevision($distribution, $rrId, $postType, $scheduledAt);
 

--- a/SDK/RootsratedSDK.php
+++ b/SDK/RootsratedSDK.php
@@ -9,7 +9,6 @@ class RootsRatedSDK {
     protected $key;
     protected $secret;
     protected $phoneHomeUrl;
-    protected $categoryName = 'RootsRated';
     protected $postType = 'Post';
     protected $applicationPath;
     private $headerSnippetAdded = false;
@@ -48,11 +47,6 @@ class RootsRatedSDK {
         if(array_key_exists('phone_home_url',$rootsrated['rootsrated']))
         {
             $this->setPhoneHomeUrl($rootsrated['rootsrated']['phone_home_url']);
-        }
-
-        if(array_key_exists('category',$rootsrated['rootsrated']))
-        {
-            $this->setCategoryName($rootsrated['rootsrated']['category']);
         }
 
         if(array_key_exists('posttype',$rootsrated['rootsrated']))
@@ -128,19 +122,6 @@ class RootsRatedSDK {
     public function isAuthenticated(){
         return ($this->hasField($this->key) && $this->hasField($this->secret) && $this->hasField($this->token));
 
-    }
-
-    public function getCategoryName()
-    {
-        return $this->categoryName;
-    }
-
-    public function setCategoryName($categoryName)
-    {
-        if($this->hasField($categoryName))
-        {
-            $this->categoryName = $categoryName;
-        }
     }
 
     public function getPostType()

--- a/SDK/RootsratedWebhook.php
+++ b/SDK/RootsratedWebhook.php
@@ -132,10 +132,9 @@ class RootsRatedWebhook
         }
 
         $distribution = $data['response']['distribution'];
-        $catName = $sdk->getCategoryName();
         $postType = $sdk->getPostType();
 
-        return $posts->postScheduling($distribution, $rrId, $catName, $postType);
+        return $posts->postScheduling($distribution, $rrId, $postType);
     }
 
     private function postGoLive($jsonHook, $posts, $sdk)
@@ -159,10 +158,9 @@ class RootsRatedWebhook
 
         $distribution = $data['response']['distribution'];
         $launchAt = $jsonHook['distribution']['launch_at'];
-        $catName = $sdk->getCategoryName();
         $postType = $sdk->getPostType();
 
-        return $posts->postGoLive($distribution, $launchAt, $rrId, $catName, $postType);
+        return $posts->postGoLive($distribution, $launchAt, $rrId, $postType);
         }
 
     public function postRevision($jsonHook, $posts, $sdk)
@@ -297,7 +295,6 @@ class RootsRatedWebhook
 
         $checks = array();
         $checks['machine_user_present'] = $options['username_exists'];
-        $checks['default_category_present'] = $options['category_exists'];
 
         $payload = array();
         $payload['system_info'] = $system_info;

--- a/SDK/config.json
+++ b/SDK/config.json
@@ -2,7 +2,6 @@
   "rootsrated":{
     "image_upload_path": "",
     "posttype": "Post",
-    "category": "RootsRated",
     "application_path": "",
     "phone_home_url" : "https://app.getmatcha.com/tidal/v1_0/"
   }

--- a/tests/mocks/RootsratedMockPosts.php
+++ b/tests/mocks/RootsratedMockPosts.php
@@ -5,12 +5,12 @@ class RootsRatedMockPosts implements RootsRatedPosts
 {
 
     // Public Functions
-    public function postScheduling($distribution, $rrId, $catName, $postType)
+    public function postScheduling($distribution, $rrId, $postType)
     {
 
     }
 
-    public function postGoLive($distribution, $launchAt, $rrId, $catName,$postType)
+    public function postGoLive($distribution, $launchAt, $rrId, $postType)
     {
 
     }
@@ -45,13 +45,10 @@ class RootsRatedMockPosts implements RootsRatedPosts
         $info['publish_posts'] =  true;
         $info['delete_published_posts'] =  true;
         $info['username_exists'] = true;
-        $info['category_exists'] = true;
         $info['plugins'] = array();
-	$info['plugins_url'] = 'wp-content/plugins/';
-      
+        $info['plugins_url'] = 'wp-content/plugins/';
+
         return $info;
-
-
     }
 
 }

--- a/tests/mocks/wp_options.json
+++ b/tests/mocks/wp_options.json
@@ -5,7 +5,6 @@
   "publish_posts": 1,
   "delete_published_posts": 0,
   "username_exists": 1,
-  "category_exists": 1,
   "plugins":[
     {
       "Version": "1.1.2",


### PR DESCRIPTION
There's no need to create a category for new posts, and some clients have complained about the creation of a new category on their site before. With the rebrand, we'd need to either rename the default category from "RootsRated" to "Matcha" or remove the category. Opting for the latter to reduce surface area and make the plugin more flexible for different WP themes.